### PR TITLE
Get balances and agent props from blocks GolosChain/cyberway-block-explorer#9

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,7 @@
     "bracketSpacing": true,
     "jsxBracketSameLine": false,
     "tabWidth": 4,
-    "printWidth": 80,
+    "printWidth": 100,
     "overrides": [
         {
             "files": ["*.yml", "*.json"],

--- a/src/controllers/Accounts.js
+++ b/src/controllers/Accounts.js
@@ -52,6 +52,7 @@ class Accounts {
                 },
             },
         ]);
+
         const tokens = [];
         if (balances && balances.length) {
             for (const balance of balances) {

--- a/src/controllers/Accounts.js
+++ b/src/controllers/Accounts.js
@@ -35,20 +35,22 @@ class Accounts {
         const balances = await BalanceModel.aggregate([
             {
                 $match: {
-                    account: accountId
-                }
-            }, {
+                    account: accountId,
+                },
+            },
+            {
                 $group: {
-                    _id: "$symbol",
+                    _id: '$symbol',
                     doc: {
-                        $first: "$$ROOT"
+                        $first: '$$ROOT',
                     },
-                }
-            }, {
+                },
+            },
+            {
                 $sort: {
-                    _id: 1
-                }
-            }
+                    _id: 1,
+                },
+            },
         ]);
         const tokens = [];
         if (balances && balances.length) {

--- a/src/controllers/Accounts.js
+++ b/src/controllers/Accounts.js
@@ -1,4 +1,5 @@
 const AccountModel = require('../models/Account');
+const BalanceModel = require('../models/TokenBalance');
 
 class Accounts {
     constructor({ dataActualizer }) {
@@ -31,6 +32,36 @@ class Accounts {
         account.grants = await this._dataActualizer.getGrants({
             account: accountId,
         });
+        const balances = await BalanceModel.aggregate([
+            {
+                $match: {
+                    account: accountId
+                }
+            }, {
+                $group: {
+                    _id: "$symbol",
+                    doc: {
+                        $first: "$$ROOT"
+                    },
+                }
+            }, {
+                $sort: {
+                    _id: 1
+                }
+            }
+        ]);
+        const tokens = [];
+        if (balances && balances.length) {
+            for (const balance of balances) {
+                const doc = balance.doc;
+                tokens.push({
+                    balance: doc.balance,
+                    payments: doc.payments,
+                    blockNum: doc.blockNum,
+                });
+            }
+        }
+        account.tokens = tokens;
 
         return account;
     }

--- a/src/controllers/Chain.js
+++ b/src/controllers/Chain.js
@@ -14,14 +14,14 @@ class Chain {
     }
 
     async getInfo() {
-        return await this._dataActualizer.getInfo()
+        return await this._dataActualizer.getInfo();
     }
 
     async getValidators() {
         const validators = await this._dataActualizer.getValidators();
         const { items } = validators;
         if (items.length) {
-            const accounts = items.map(({account}) => account);
+            const accounts = items.map(({ account }) => account);
             const properties = await StakeAgentModel.find(
                 {
                     account: { $in: accounts },
@@ -30,12 +30,14 @@ class Chain {
                 {},
                 {
                     sort: { blockNum: -1 },
-                    lean: true
+                    lean: true,
                 }
             );
             const missing = [];
             items.forEach(item => {
-                const props = properties.find(({ account }) => account == item.account);
+                const props = properties.find(
+                    ({ account }) => account == item.account
+                );
                 if (props) {
                     const { fee, proxyLevel, minStake } = props;
                     item.props = {
@@ -51,7 +53,7 @@ class Chain {
                 // this branch allows to fetch missing agents info from api without "replaying" events,
                 // but it makes 50+ requests first time. also it's not precise in case of fork (block num can change).
                 // This mechanism should be removed when filling data from genesis become ready
-                const info = await this._dataActualizer.getInfo({ force: true });
+                const info = await this._dataActualizer.getInfo();
                 for (const acc of missing) {
                     const props = await this._dataActualizer.getAgent(acc);
                     if (props) {
@@ -69,14 +71,16 @@ class Chain {
                             symbol: 'CYBER',
                             fee,
                             proxyLevel,
-                            minStake
+                            minStake,
                         });
 
                         try {
                             await agentModel.save();
-                        } catch (err) {
-                            if (!(err.name === 'MongoError' && err.code === 11000)) {
-                                throw err;
+                        } catch (e) {
+                            if (
+                                !(e.name === 'MongoError' && e.code === 11000)
+                            ) {
+                                throw e;
                             }
                         }
                     }

--- a/src/controllers/Chain.js
+++ b/src/controllers/Chain.js
@@ -1,3 +1,4 @@
+const StakeAgentModel = require('../models/StakeAgent');
 class Chain {
     constructor({ dataActualizer }) {
         this._dataActualizer = dataActualizer;
@@ -12,8 +13,77 @@ class Chain {
         };
     }
 
+    async getInfo() {
+        return await this._dataActualizer.getInfo()
+    }
+
     async getValidators() {
-        return await this._dataActualizer.getValidators()
+        const validators = await this._dataActualizer.getValidators();
+        const { items } = validators;
+        if (items.length) {
+            const accounts = items.map(({account}) => account);
+            const properties = await StakeAgentModel.find(
+                {
+                    account: { $in: accounts },
+                    symbol: 'CYBER',
+                },
+                {},
+                {
+                    sort: { blockNum: -1 },
+                    lean: true
+                }
+            );
+            const missing = [];
+            items.forEach(item => {
+                const props = properties.find(({ account }) => account == item.account);
+                if (props) {
+                    const { fee, proxyLevel, minStake } = props;
+                    item.props = {
+                        fee,
+                        proxyLevel,
+                        minStake,
+                    };
+                } else {
+                    missing.push(item.account);
+                }
+            });
+            if (missing) {
+                // this branch allows to fetch missing agents info from api without "replaying" events,
+                // but it makes 50+ requests first time. also it's not precise in case of fork (block num can change).
+                // This mechanism should be removed when filling data from genesis become ready
+                const info = await this._dataActualizer.getInfo({ force: true });
+                for (const acc of missing) {
+                    const props = await this._dataActualizer.getAgent(acc);
+                    if (props) {
+                        const { fee, proxyLevel, minStake } = props;
+                        const item = items.find(({ account }) => account === acc);
+                        item.props = {
+                            fee,
+                            proxyLevel,
+                            minStake,
+                        };
+
+                        const agentModel = new StakeAgentModel({
+                            blockNum: info.head_block_num,
+                            account: acc,
+                            symbol: 'CYBER',
+                            fee,
+                            proxyLevel,
+                            minStake
+                        });
+
+                        try {
+                            await agentModel.save();
+                        } catch (err) {
+                            if (!(err.name === 'MongoError' && err.code === 11000)) {
+                                throw err;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return validators;
     }
 }
 

--- a/src/models/StakeAgent.js
+++ b/src/models/StakeAgent.js
@@ -1,0 +1,49 @@
+const core = require('gls-core-service');
+const MongoDB = core.services.MongoDB;
+
+// TODO: inherit from "undoable model"
+module.exports = MongoDB.makeModel(
+    'StakeAgent',
+    {
+        account: {
+            type: String,
+            required: true,
+        },
+        symbol: {
+            type: String,
+            required: true,
+        },
+        fee: {
+            type: Number,
+        },
+        proxyLevel: {
+            type: Number,
+        },
+        minStake: {
+            type: Number,
+        },
+        blockNum: {
+            type: Number,
+            required: true,
+        },
+    },
+    {
+        index: [
+            {
+                fields: {
+                    account: 1,
+                    symbol: 1,
+                    blockNum: -1,
+                },
+                options: {
+                    unique: true,
+                },
+            },
+            {
+                fields: {
+                    blockNum: -1,
+                },
+            },
+        ],
+    }
+);

--- a/src/models/TokenBalance.js
+++ b/src/models/TokenBalance.js
@@ -12,7 +12,7 @@ module.exports = MongoDB.makeModel(
             required: true,
         },
         symbol: {
-            type: String,       // should simplify fetching unique balances
+            type: String, // should simplify fetching unique balances
             required: true,
         },
         balance: {
@@ -37,7 +37,7 @@ module.exports = MongoDB.makeModel(
                     blockNum: -1,
                 },
                 options: {
-                    unique: true,    // there can be several changes in one block, overwrite with last one
+                    unique: true, // there can be several changes in one block, overwrite with last one
                 },
             },
             {

--- a/src/models/TokenBalance.js
+++ b/src/models/TokenBalance.js
@@ -1,0 +1,50 @@
+const core = require('gls-core-service');
+const MongoDB = core.services.MongoDB;
+
+// TODO: there are fields and indexes common for all revertable (on fork) models,
+// it's good to have some inheritance or so to remove duplicating code
+// TODO: implement removal of old records: we don't need whole history for such objects as balance
+module.exports = MongoDB.makeModel(
+    'TokenBalance',
+    {
+        account: {
+            type: String,
+            required: true,
+        },
+        symbol: {
+            type: String,       // should simplify fetching unique balances
+            required: true,
+        },
+        balance: {
+            type: String,
+            required: true,
+        },
+        payments: {
+            type: String,
+            required: true,
+        },
+        blockNum: {
+            type: Number,
+            required: true,
+        },
+    },
+    {
+        index: [
+            {
+                fields: {
+                    account: 1,
+                    symbol: 1,
+                    blockNum: -1,
+                },
+                options: {
+                    unique: true,    // there can be several changes in one block, overwrite with last one
+                },
+            },
+            {
+                fields: {
+                    blockNum: -1,
+                },
+            },
+        ],
+    }
+);

--- a/src/services/DataActualizer.js
+++ b/src/services/DataActualizer.js
@@ -150,11 +150,9 @@ class DataActualizer extends BasicService {
                 },
             },
         });
+
         const agent = data.rows
-            .filter(
-                agent =>
-                    agent.account === account && agent.token_code === 'CYBER'
-            )
+            .filter(agent => agent.account === account && agent.token_code === 'CYBER')
             .map(agent => ({
                 account,
                 symbol: agent.token_code,
@@ -162,17 +160,15 @@ class DataActualizer extends BasicService {
                 proxyLevel: agent.proxy_level,
                 minStake: agent.min_own_staked,
             }))[0];
+
         return agent;
     }
 
     async _callChainApi({ endpoint, args }) {
-        const response = await fetch(
-            `${env.GLS_CYBERWAY_CONNECT}/v1/chain/${endpoint}`,
-            {
-                method: 'POST',
-                body: JSON.stringify(args),
-            }
-        );
+        const response = await fetch(`${env.GLS_CYBERWAY_CONNECT}/v1/chain/${endpoint}`, {
+            method: 'POST',
+            body: JSON.stringify(args),
+        });
 
         return await response.json();
     }
@@ -244,10 +240,7 @@ class DataActualizer extends BasicService {
             await this.addUsernames(candidates, 'account');
 
             this._validators = candidates
-                .filter(
-                    candidate =>
-                        candidate.enabled && candidate.token_code === 'CYBER'
-                )
+                .filter(candidate => candidate.enabled && candidate.token_code === 'CYBER')
                 .map(candidate => ({
                     account: candidate.account,
                     enabled: candidate.enabled,
@@ -255,8 +248,7 @@ class DataActualizer extends BasicService {
                     signKey: candidate.signing_key,
                     votes: candidate.votes,
                     username: candidate.username,
-                    percent:
-                        100 * candidate.votes / this._stakeStat.total_votes,
+                    percent: (100 * candidate.votes) / this._stakeStat.total_votes,
                 }));
 
             this._validatorsUpdateTime = new Date();
@@ -268,7 +260,7 @@ class DataActualizer extends BasicService {
     _clearCache() {
         const now = Date.now();
 
-        for (const [ accountId, grants ] of Object.entries(this._grantsCache)) {
+        for (const [accountId, grants] of Object.entries(this._grantsCache)) {
             if (now - grants.updateTime > ACCOUNTS_CACHE_EXPIRE) {
                 delete this._grantsCache[accountId];
             }

--- a/src/services/DataActualizer.js
+++ b/src/services/DataActualizer.js
@@ -150,17 +150,18 @@ class DataActualizer extends BasicService {
                 },
             },
         });
-        const agent = data.rows.filter(
-            agent => agent.account === account && agent.token_code === 'CYBER'
-        ).map(
-            agent => ({
+        const agent = data.rows
+            .filter(
+                agent =>
+                    agent.account === account && agent.token_code === 'CYBER'
+            )
+            .map(agent => ({
                 account,
                 symbol: agent.token_code,
                 fee: agent.fee,
                 proxyLevel: agent.proxy_level,
                 minStake: agent.min_own_staked,
-            })
-        )[0];
+            }))[0];
         return agent;
     }
 
@@ -255,7 +256,7 @@ class DataActualizer extends BasicService {
                     votes: candidate.votes,
                     username: candidate.username,
                     percent:
-                        (100 * candidate.votes) / this._stakeStat.total_votes,
+                        100 * candidate.votes / this._stakeStat.total_votes,
                 }));
 
             this._validatorsUpdateTime = new Date();
@@ -267,7 +268,7 @@ class DataActualizer extends BasicService {
     _clearCache() {
         const now = Date.now();
 
-        for (const [accountId, grants] of Object.entries(this._grantsCache)) {
+        for (const [ accountId, grants ] of Object.entries(this._grantsCache)) {
             if (now - grants.updateTime > ACCOUNTS_CACHE_EXPIRE) {
                 delete this._grantsCache[accountId];
             }

--- a/src/services/Subscriber.js
+++ b/src/services/Subscriber.js
@@ -336,10 +336,15 @@ class Subscriber extends BasicService {
                         if (handler) {
                             handler(action, storage, stats);
                         }
+
                         const eventsHandlers = contractHandlers.EVENTS;
                         if (eventsHandlers) {
                             for (const event of action.events) {
-                                if (event.code !== action.code) continue; // not required for now
+                                if (event.code !== action.code) {
+                                    // not required for now
+                                    continue;
+                                }
+
                                 const handler = eventsHandlers[event.event];
                                 if (handler) {
                                     handler(event, storage, stats);
@@ -621,7 +626,10 @@ class Subscriber extends BasicService {
     }
 
     async _saveBalanceUpdates(balances, blockNum) {
-        if (Object.keys(balances).length === 0) return;
+        if (Object.keys(balances).length === 0) {
+            return;
+        }
+
         await Promise.all(
             Object.values(balances).map(async ({ account, symbol, balance, payments }) => {
                 const balanceModel = new TokenBalanceModel({
@@ -644,7 +652,10 @@ class Subscriber extends BasicService {
     }
 
     async _saveAgentUpdates(agents, blockNum) {
-        if (Object.keys(agents).length === 0) return;
+        if (Object.keys(agents).length === 0) {
+            return;
+        }
+
         await Promise.all(
             Object.keys(agents).map(async key => {
                 const [account, symbol] = key.split(' ');

--- a/src/services/Subscriber.js
+++ b/src/services/Subscriber.js
@@ -322,7 +322,7 @@ class Subscriber extends BasicService {
                 stats.actions.count += transaction.actions.length;
 
                 const handlers = {
-                    'cyber': {
+                    cyber: {
                         newaccount: this._newAccountAction,
                     },
                     'cyber.stake': {
@@ -348,8 +348,7 @@ class Subscriber extends BasicService {
                         const eventsHandlers = contractHandlers.EVENTS;
                         if (eventsHandlers) {
                             for (const event of action.events) {
-                                if (event.code !== action.code)
-                                    continue;   // not required for now
+                                if (event.code !== action.code) continue; // not required for now
                                 const handler = eventsHandlers[event.event];
                                 if (handler) {
                                     handler(event, storage, stats);
@@ -634,10 +633,11 @@ class Subscriber extends BasicService {
     }
 
     async _saveBalanceUpdates(balances, blockNum) {
-        if (Object.keys(balances).length === 0)
-            return;
+        if (Object.keys(balances).length === 0) return;
         await Promise.all(
-            Object.values(balances).map(async ({ account, symbol, balance, payments }) => {
+            Object.values(
+                balances
+            ).map(async ({ account, symbol, balance, payments }) => {
                 const balanceModel = new TokenBalanceModel({
                     blockNum,
                     account,
@@ -658,17 +658,16 @@ class Subscriber extends BasicService {
     }
 
     async _saveAgentUpdates(agents, blockNum) {
-        if (Object.keys(agents).length === 0)
-            return;
+        if (Object.keys(agents).length === 0) return;
         await Promise.all(
-            Object.keys(agents).map(async (key) => {
+            Object.keys(agents).map(async key => {
                 const [ account, symbol ] = key.split(' ');
                 const value = agents[key];
 
                 const previous = await StakeAgentModel.findOne(
                     {
                         account,
-                        symbol
+                        symbol,
                     },
                     {},
                     {
@@ -690,7 +689,7 @@ class Subscriber extends BasicService {
                     symbol,
                     fee,
                     proxyLevel,
-                    minStake
+                    minStake,
                 });
 
                 try {

--- a/src/services/Subscriber.js
+++ b/src/services/Subscriber.js
@@ -50,9 +50,7 @@ class Subscriber extends BasicService {
                 await this._setIrreversibleBlockNum(data);
                 break;
             case 'FORK':
-                Logger.warn(
-                    `Fork detected, new safe base on block num: ${data.baseBlockNum}`
-                );
+                Logger.warn(`Fork detected, new safe base on block num: ${data.baseBlockNum}`);
                 await this._deleteInvalidEntries(data.baseBlockNum);
                 break;
             default:
@@ -123,20 +121,14 @@ class Subscriber extends BasicService {
             );
         }
 
-        const { counters, storage } = this._calcBlockCounters(
-            block,
-            transactions,
-            parentBlock
-        );
+        const { counters, storage } = this._calcBlockCounters(block, transactions, parentBlock);
 
         const blockModel = new BlockModel({
             id: block.id,
             parentId: block.parentId,
             blockNum: block.blockNum,
             blockTime: block.blockTime,
-            transactionIds: block.transactions.map(
-                transaction => transaction.id
-            ),
+            transactionIds: block.transactions.map(transaction => transaction.id),
             counters,
             codes: Object.keys(blockIndexes.codes),
             actions: Object.keys(blockIndexes.actions),
@@ -274,7 +266,7 @@ class Subscriber extends BasicService {
                 agent.minStake = args.min_own_staked;
                 break;
             default:
-                Logger.warn(`Wrong action ${action.action} passed to _updateAgentAction`)
+                Logger.warn(`Wrong action ${action.action} passed to _updateAgentAction`);
         }
     }
 
@@ -308,16 +300,15 @@ class Subscriber extends BasicService {
 
         const storage = {
             newAccounts: [],
-            balances: {},       // updates if several balance changes in one block
-            agents: {},         // updates if several fields of agent changed in one block
+            balances: {}, // updates if several balance changes in one block
+            agents: {}, // updates if several fields of agent changed in one block
         };
 
         const tStats = stats.transactions;
 
         if (transactions) {
             for (const transaction of transactions) {
-                tStats[transaction.status] =
-                    (tStats[transaction.status] || 0) + 1;
+                tStats[transaction.status] = (tStats[transaction.status] || 0) + 1;
 
                 stats.actions.count += transaction.actions.length;
 
@@ -363,10 +354,7 @@ class Subscriber extends BasicService {
         return {
             counters: {
                 current: stats,
-                total: this._mergeStats(
-                    parentBlock ? parentBlock.counters.total : null,
-                    stats
-                ),
+                total: this._mergeStats(parentBlock ? parentBlock.counters.total : null, stats),
             },
             storage,
         };
@@ -635,9 +623,7 @@ class Subscriber extends BasicService {
     async _saveBalanceUpdates(balances, blockNum) {
         if (Object.keys(balances).length === 0) return;
         await Promise.all(
-            Object.values(
-                balances
-            ).map(async ({ account, symbol, balance, payments }) => {
+            Object.values(balances).map(async ({ account, symbol, balance, payments }) => {
                 const balanceModel = new TokenBalanceModel({
                     blockNum,
                     account,
@@ -661,7 +647,7 @@ class Subscriber extends BasicService {
         if (Object.keys(agents).length === 0) return;
         await Promise.all(
             Object.keys(agents).map(async key => {
-                const [ account, symbol ] = key.split(' ');
+                const [account, symbol] = key.split(' ');
                 const value = agents[key];
 
                 const previous = await StakeAgentModel.findOne(


### PR DESCRIPTION
+ add 2 models, which can be reverted on fork
+ generalize obtaining of undoable models data in Subscriber
+ add balances info to getAccount response
+ add agent properties to getValidators response: also implemented reading from api if data missing db (to start explorer without EE replay)
+ fix latestPick value of validator so client can detect it's UTC (Note: requires to update frontend to preserve "never" at conforming places)
