### PR TITLE
feat: add AccountBucket to store accumulated bucket-based values #29

### DIFF
--- a/src/controllers/Genesis.js
+++ b/src/controllers/Genesis.js
@@ -53,7 +53,6 @@ class GenesisContent {
             registrationTime = new Date(created + 'Z');
         }
 
-        // TODO: fix EE genesis to contain complete key data https://github.com/cyberway/cyberway/issues/1120
         const makePermission = keys => {
             return {
                 threshold: 1, // will be wrong for owner with recovery
@@ -72,9 +71,9 @@ class GenesisContent {
             reputation,
             registrationTime,
             keys: {
-                owner: makePermission(data.owner_keys),
-                active: makePermission(data.active_keys),
-                posting: makePermission(data.posting_keys),
+                owner: data.owner_keys ? makePermission(data.owner_keys) : data.owner_auth,
+                active: data.active_keys ? makePermission(data.active_keys) : data.active_auth,
+                posting: data.posting_keys ? makePermission(data.posting_keys) : data.posting_auth,
             },
         });
         this._balancesBulk.addEntry({

--- a/src/models/AccountBucket.js
+++ b/src/models/AccountBucket.js
@@ -1,0 +1,53 @@
+const core = require('cyberway-core-service');
+const MongoDB = core.services.MongoDB;
+
+// Accumulate different values on per-account base.
+// It's too slow to calculate buckets with dynamic ranges, they can be used only for short time
+// periods (week or less). For months and total we use buckets fith fixed boundaries.
+module.exports = MongoDB.makeModel(
+    'AccountBucket',
+    {
+        bucket: {
+            type: String,
+            required: true,
+        },
+        account: {
+            type: String,
+            required: true,
+        },
+        blocksCount: {
+            type: Number,
+            required: true,
+            default: 0,
+        },
+        missesCount: {
+            type: Number,
+            required: true,
+            default: 0,
+        },
+    },
+    {
+        index: [
+            {
+                fields: {
+                    bucket: 1,
+                    account: 1,
+                },
+                options: {
+                    unique: true,
+                },
+            },
+            {
+                fields: {
+                    account: 1,
+                    bucket: 1,
+                },
+            },
+            {
+                fields: {
+                    bucket: 1,
+                },
+            },
+        ],
+    }
+);

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -23,17 +23,39 @@ function extractByPath(data, path) {
     }
 }
 
-async function saveModelIgnoringDups(model) {
+async function saveModelIgnoringDups(model, errName) {
     try {
         await model.save();
     } catch (err) {
-        if (!(err.name === 'MongoError' && err.code === 11000)) {
+        if (errName === undefined) {
+            errName = 'MongoError';
+        }
+        if (!(err.name === errName && err.code === 11000)) {
             throw err;
         }
     }
 }
 
+// use 2-digits Year and Month (starts from 0) as id (e.g. "1909" for October 2019)
+function dateToBucketId(date) {
+    return `${(date.getYear() - 100) * 100 + date.getMonth()}`;
+}
+
+function arrayToDict({ array, key, singleValue }) {
+    const result = {};
+
+    for (const item of array) {
+        const k = item[key];
+        delete item[key];
+        result[k] = singleValue === undefined ? item : item[singleValue];
+    }
+
+    return result;
+}
+
 module.exports = {
     extractByPath,
     saveModelIgnoringDups,
+    dateToBucketId,
+    arrayToDict,
 };


### PR DESCRIPTION
also:
+ store to buckets in Subscriber (blocks) and Schedule (missed blocks)
+ update getValidators to use buckets
+ add block producing info to getAccount response
+ add block miss info on hourly graph
+ support genesis with full-auth in accounts