### PR TITLE
fix: use flat paths in account path model #38

### DIFF
--- a/src/models/AccountPath.js
+++ b/src/models/AccountPath.js
@@ -17,12 +17,10 @@ module.exports = MongoDB.makeModel(
             required: true,
         },
         accountPaths: [
-            [
-                {
-                    type: String,
-                    required: true,
-                },
-            ],
+            {
+                type: String,
+                required: true,
+            },
         ],
     },
     {

--- a/src/services/Subscriber.js
+++ b/src/services/Subscriber.js
@@ -544,6 +544,7 @@ class Subscriber extends BasicService {
                     Logger.error('Unsupported case, structure with base:', struct);
                 }
 
+                // TODO: field type can contain name alias or struct containing name inside (recursive)
                 entries.push({
                     account,
                     blockNum,


### PR DESCRIPTION
note: data passed to model is already in "flat" form, but mongo model code automatically normalizes `[some]` value to `[[some]]` if model definition says it requires embedded array.

resolves #38