### PR TITLE
feat: support msig schedule, waits + return msig contract version

### DIFF
--- a/src/controllers/Schedule.js
+++ b/src/controllers/Schedule.js
@@ -49,7 +49,7 @@ class Schedule {
         }
 
         if (blockNum <= this.blockNum) {
-            this.log(`Got already processed block: ${blockTime}`);
+            this.log(`Got already processed block: ${blockTime.toISOString()}`);
             return;
         }
         if (blockNum !== this.blockNum + 1) {

--- a/src/controllers/StateReader.js
+++ b/src/controllers/StateReader.js
@@ -23,6 +23,7 @@ class StateReader extends Basic {
             'StakeCandidates',
             'Proposals',
             'ProposalApprovals',
+            'ProposalWaits',
             'Permissions',
             'PermissionLinks',
             'ResState',
@@ -61,6 +62,7 @@ class StateReader extends Basic {
     async getStakeCandidates(params) {}
     async Proposals(params) {}
     async ProposalApprovals(params) {}
+    async ProposalWaits(params) {}
     async Permissions(params) {}
     async PermissionLinks(params) {}
     async ResState() {}

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -36,6 +36,8 @@ module.exports = MongoDB.makeModel(
         creator: {
             type: String,
         },
+        codeVersion: { type: Number },
+        abiVersion: { type: Number },
     },
     {
         index: [

--- a/src/models/Proposal.js
+++ b/src/models/Proposal.js
@@ -24,6 +24,7 @@ module.exports = MongoDB.makeModel(
             status: { type: String }, // "exec"/"cancel"/undefined for active proposals
             execTrxId: { type: String },
         },
+        scheduled: { type: Date }, // only set if scheduled
     },
     {
         index: [


### PR DESCRIPTION
* support `schedule` action introduced in `cyber.msig` v2;
* support proposal waits (`cyber.msig` v2);
* `getProposal` returns msig contract version;
* store versions of contracts abi and code (increment on `setabi`/`setcode`);
* minor fixes.

required for goloschain/cyberway-block-explorer#130